### PR TITLE
+ Added user update endpoint

### DIFF
--- a/app/Http/Controllers/Auth/UserController.php
+++ b/app/Http/Controllers/Auth/UserController.php
@@ -197,4 +197,49 @@ class UserController extends Controller
         $user = Auth::user();
         return response()->json(['success' => $user], $this->successStatus);
     }
+    
+    public function update(Request $request){
+      $data = $request->all();
+      if(Auth::check()){
+        $user = Auth::user();
+        
+        if(isset($data['name'])){
+          $name = explode(' ', $data['name']);
+          $user->first_name = isset($name[0]) ? $name[0] : '';
+          $user->last_name = isset($name[1]) ? implode(' ', array_slice($name, 1)) : '';
+          $user->name = $data['name'];
+        }
+        
+        if(isset($data['email'])){
+          $validator = Validator::make($data, ['email' => ['required', 'string', 'email', 'max:255', 'unique:users']]);
+          
+          if ($validator->fails())
+            return response()->json(['error' => $validator->errors()], 401);
+          
+          $user->email = $data['email'];
+        }
+        
+        // set the password only if does not already exists
+        if(isset($data['password']) && empty($user->password) && $user->user_type == config('user.user_type.guest')){
+          $validator = Validator::make($data, ['password' => ['required', 'string', 'min:8']]);
+          
+          if ($validator->fails())
+            return response()->json(['error' => $validator->errors()], 401);
+          
+            $user->password = Hash::make($data['password']);
+        }
+        
+        // if both email and password exist for user change its type
+        if(!empty($user->email) && !empty($user->password) && $user->user_type == config('user.user_type.guest'))
+          $user->user_type = config('user.user_type.default');
+          
+        if($user->update()){
+          $success['token'] =  $user->createToken('lazysuzy-web')->accessToken;
+          $success['user'] =  $user;
+          return response()->json(['success' => $success], $this->successStatus);
+        }
+        else
+          return response()->json(['error' => ['error' => "unknown error"]], 401);
+      }
+    }
 }

--- a/routes/web.php
+++ b/routes/web.php
@@ -62,6 +62,7 @@ Route::get('login/{driver}/callback', 'Auth\LoginController@handleProviderCallba
 
 Route::post('/api/login', 'Auth\UserController@login');
 Route::post('/api/register', 'Auth\UserController@register');
+Route::post('/api/user/update', 'Auth\UserController@update')->middleware('auth:api');
 Route::get('/api/logout', 'Auth\UserController@logout');
 
 


### PR DESCRIPTION
  - the endpoint is hosted on /api/user/update (requires authorization token)
  - then endpoint can update user's [name, email and password (if previously not set)]
  - user type will be converted from guest to default if both email and password are set
  - the endpoint will always return user object